### PR TITLE
added jinja2 tags

### DIFF
--- a/wagtailmetadata/jinja2tags.py
+++ b/wagtailmetadata/jinja2tags.py
@@ -1,0 +1,20 @@
+import jinja2
+from jinja2.ext import Extension
+from wagtailmetadata import tags
+
+
+@jinja2.contextfunction
+def meta_tags(context):
+    request = context['request']
+    page = context['page']
+
+    return jinja2.Markup(tags.meta_tags(request, page))
+
+
+class WagtailMetadataExtension(Extension):
+    def __init__(self, environment):
+        super().__init__(environment)
+
+        self.environment.globals.update({
+            'meta_tags': meta_tags,
+        })

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -1,0 +1,29 @@
+import warnings
+
+from django.conf import settings
+from django.template.loader import render_to_string
+from wagtail.wagtailcore.models import Site
+from wagtailmetadata.models import SiteMetadataPreferences
+
+
+def meta_tags(request, page):
+    site = Site.find_for_request(request)
+    try:
+        global_settings = SiteMetadataPreferences.objects.get(site=site)
+    except SiteMetadataPreferences.DoesNotExist:
+        warnings.warn('Your global metadata settings are not defined for {0}'.format(site))
+        return ''
+
+    page.meta_image = page.search_image or global_settings.site_image
+    page.meta_description = page.search_description or global_settings.site_description
+
+    if page.meta_image:
+        page.meta_image = page.meta_image.get_rendition(filter='original')
+        page.meta_image.full_url = request.build_absolute_uri(page.meta_image.url)
+
+    page.absolute_url = request.build_absolute_uri(page.url)
+    return render_to_string('wagtailmetadata/parts/tags.html', {
+        'page': page,
+        'site_name': settings.WAGTAIL_SITE_NAME,
+        'global_settings': global_settings,
+    })

--- a/wagtailmetadata/templatetags/wagtailmetadata_tags.py
+++ b/wagtailmetadata/templatetags/wagtailmetadata_tags.py
@@ -1,37 +1,12 @@
-import warnings
-
 from django import template
-from django.conf import settings
-from django.template.loader import render_to_string
-from wagtail.wagtailcore.models import Site
-from wagtailmetadata.models import SiteMetadataPreferences
+from wagtailmetadata import tags
 
 register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
 def meta_tags(context):
-    instance = context['self']
     request = context['request']
     page = context['self']
-    site = Site.find_for_request(request)
-    try:
-        global_settings = SiteMetadataPreferences.objects.get(site=site)
-    except SiteMetadataPreferences.DoesNotExist:
-        warnings.warn('Your global metadata settings are not defined for {0}'.format(site))
-        return ''
 
-    instance.meta_image = instance.search_image or global_settings.site_image
-    instance.meta_description = instance.search_description or global_settings.site_description
-
-    if instance.meta_image:
-        instance.meta_image = instance.meta_image.get_rendition(filter='original')
-        instance.meta_image.full_url = request.build_absolute_uri(instance.meta_image.url)
-
-    page.absolute_url = request.build_absolute_uri(page.url)
-    return render_to_string('wagtailmetadata/parts/tags.html', {
-        'instance': instance,
-        'page': page,
-        'site_name': settings.WAGTAIL_SITE_NAME,
-        'global_settings': global_settings,
-    })
+    return tags.meta_tags(request, page)


### PR DESCRIPTION
need jinja2 support.

moved common code to tags.py file and created jinja2tags.py.
also removed duplication of instance and page, replaced with just page.
In need of tests & documentation, for whole project.