### PR TITLE
Fix page description bug introduced in #8

### DIFF
--- a/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
+++ b/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
@@ -2,19 +2,19 @@
 
 <meta name="twitter:card" content="{{global_settings.card_type}}">
 <meta name="twitter:title" content="{{page.title}}">
-<meta name="twitter:description" content="{{instance.meta_description}}">
+<meta name="twitter:description" content="{{page.meta_description}}">
 <meta name="twitter:image" content="{{meta_image.full_url}}">
 
 <meta property="og:url" content="{{page.absolute_url}}" />
 <meta property="og:title" content="{{page.title}}" />
-<meta property="og:description" content="{{instance.meta_description}}" />
+<meta property="og:description" content="{{page.meta_description}}" />
 <meta property="og:site_name" content="{{site_name}}" />
 <meta property="og:image" content="{{meta_image.full_url}}" />
 
 <meta itemprop='url' content='{{page.absolute_url}}'/>
 <meta itemprop="name" content="{{page.title}}">
-<meta itemprop='description' content='{{instance.meta_description}}' />
+<meta itemprop='description' content='{{page.meta_description}}' />
 <meta itemprop='image' content='{{meta_image.full_url}}' />
 
-<meta name="description" content="{{instance.meta_description}}">
+<meta name="description" content="{{page.meta_description}}">
 {% endwith %}


### PR DESCRIPTION
As `instance` was removed from the context of the template rendering in #8, it also needed to be changed within the template.