### PR TITLE
No mutation in tags

### DIFF
--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -88,16 +88,70 @@ class TemplateCase(object):
             'itemprop': 'name', 'content': self.page.title
         }), out)
         self.assertInHTML(self.meta({
-            'itemprop': 'description', 'content': self.page.meta_description
+            'itemprop': 'description', 'content': self.settings.site_description,
         }), out)
         self.assertInHTML(self.meta({
-            'itemprop': 'image', 'content': self.page.meta_image.full_url
+            'itemprop': 'image',
+            'content': get_meta_image_url(self.request, self.settings.site_image),
         }), out)
 
     def test_generic_render(self):
         out = self.render_meta()
         self.assertInHTML(self.meta({
-            'name': 'description', 'content': self.page.meta_description
+            'name': 'description', 'content': self.settings.site_description,
+        }), out)
+
+    def fill_out_page_meta_fields(self):
+        self.page.search_description = 'Hello, world'
+        self.page.search_image = Image.objects.create(
+            title='Page image', file=get_test_image_file())
+
+    def test_page_twitter_render(self):
+        self.fill_out_page_meta_fields()
+
+        out = self.render_meta()
+
+        self.assertInHTML(self.meta({
+            'name': 'twitter:description', 'content': self.page.search_description,
+        }), out)
+        self.assertInHTML(self.meta({
+            'name': 'twitter:image',
+            'content': get_meta_image_url(self.request, self.page.search_image),
+        }), out)
+
+    def test_page_og_render(self):
+        self.fill_out_page_meta_fields()
+
+        out = self.render_meta()
+
+        self.assertInHTML(self.meta({
+            'property': 'og:description', 'content': self.page.search_description,
+        }), out)
+        self.assertInHTML(self.meta({
+            'property': 'og:image',
+            'content': get_meta_image_url(self.request, self.page.search_image),
+        }), out)
+
+    def test_page_misc_render(self):
+        self.fill_out_page_meta_fields()
+
+        out = self.render_meta()
+
+        self.assertInHTML(self.meta({
+            'itemprop': 'description', 'content': self.page.search_description,
+        }), out)
+        self.assertInHTML(self.meta({
+            'itemprop': 'image',
+            'content': get_meta_image_url(self.request, self.page.search_image),
+        }), out)
+
+    def test_page_generic_render(self):
+        self.fill_out_page_meta_fields()
+
+        out = self.render_meta()
+
+        self.assertInHTML(self.meta({
+            'name': 'description', 'content': self.page.search_description,
         }), out)
 
 

--- a/wagtailmetadata/tags.py
+++ b/wagtailmetadata/tags.py
@@ -6,24 +6,34 @@ from wagtail.wagtailcore.models import Site
 from wagtailmetadata.models import SiteMetadataPreferences
 
 
+def get_meta_image_url(request, image):
+    """
+    Resize an image for metadata tags, and return an absolute URL to it.
+    """
+    rendition = image.get_rendition(filter='original')
+    return request.build_absolute_uri(rendition.url)
+
+
 def meta_tags(request, page):
     site = Site.find_for_request(request)
+
     try:
         global_settings = SiteMetadataPreferences.objects.get(site=site)
     except SiteMetadataPreferences.DoesNotExist:
         warnings.warn('Your global metadata settings are not defined for {0}'.format(site))
         return ''
 
-    page.meta_image = page.search_image or global_settings.site_image
-    page.meta_description = page.search_description or global_settings.site_description
-
-    if page.meta_image:
-        page.meta_image = page.meta_image.get_rendition(filter='original')
-        page.meta_image.full_url = request.build_absolute_uri(page.meta_image.url)
-
-    page.absolute_url = request.build_absolute_uri(page.url)
-    return render_to_string('wagtailmetadata/parts/tags.html', {
+    context = {
         'page': page,
         'site_name': settings.WAGTAIL_SITE_NAME,
         'global_settings': global_settings,
-    })
+        'meta_description': (
+            page.search_description or global_settings.site_description),
+        'meta_image': None,
+    }
+
+    meta_image = page.search_image or global_settings.site_image
+    if meta_image:
+        context['meta_image'] = get_meta_image_url(request, meta_image)
+
+    return render_to_string('wagtailmetadata/parts/tags.html', context)

--- a/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
+++ b/wagtailmetadata/templates/wagtailmetadata/parts/tags.html
@@ -1,17 +1,17 @@
 <meta name="twitter:card" content="{{global_settings.card_type}}">
 <meta name="twitter:title" content="{{page.title}}">
-<meta name="twitter:description" content="{{page.meta_description}}">
-<meta name="twitter:image" content="{{page.meta_image.full_url}}">
+<meta name="twitter:description" content="{{meta_description}}">
+<meta name="twitter:image" content="{{meta_image}}">
 
 <meta property="og:url" content="{{page.full_url}}" />
 <meta property="og:title" content="{{page.title}}" />
-<meta property="og:description" content="{{page.meta_description}}" />
+<meta property="og:description" content="{{meta_description}}" />
 <meta property="og:site_name" content="{{site_name}}" />
-<meta property="og:image" content="{{page.meta_image.full_url}}" />
+<meta property="og:image" content="{{meta_image}}" />
 
 <meta itemprop='url' content='{{page.full_url}}'/>
 <meta itemprop="name" content="{{page.title}}">
-<meta itemprop='description' content='{{page.meta_description}}' />
-<meta itemprop='image' content='{{page.meta_image.full_url}}' />
+<meta itemprop='description' content='{{meta_description}}' />
+<meta itemprop='image' content='{{meta_image}}' />
 
-<meta name="description" content="{{page.meta_description}}">
+<meta name="description" content="{{meta_description}}">


### PR DESCRIPTION
This depends upon your tests PR, so I'll rebase this once the tests are merged.

This removes the mutation of the page and image objects sent in to the `meta_tags`.