### PR TITLE
Add tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.egg-info
 dist/
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: python
+cache: pip
+
+# Matrix of build options
+python:
+  - '3.4'
+  - '3.5'
+
+env:
+  global:
+    - DJANGO_SETTINGS_MODULE="tests.settings"
+    - TOX_ENV=
+  matrix:
+    - DJANGO='19' WAGTAIL='16'
+    - DJANGO='110' WAGTAIL='16'
+
+before_install:
+    # - sudo add-apt-repository ppa:mc3man/trusty-media -y // Inlcudes all multimedia options but 404s currently :(
+    - sudo apt-get update -qq
+    - sudo apt-get install ffmpeg -y
+
+install:
+  - pip install --upgrade pip wheel tox
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/virtualenv
+
+script:
+  # Run tox using either a specific environment from TOX_ENV,
+  # or building one from the environment variables
+  - tox -e "${TOX_ENV:-py${TRAVIS_PYTHON_VERSION/./}-dj${DJANGO}-wt${WAGTAIL}}"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/takeflight/wagtail-metadata',
 
     install_requires=[
-        'wagtail>=1.0',
+        'wagtail>=1.6',
     ],
     zip_safe=False,
     license='BSD License',
@@ -33,6 +33,9 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Framework :: Django',
         'License :: OSI Approved :: BSD License',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+skip_missing_interpreters = True
+
+envlist =
+	py{34,35}-dj{19,110}-wt{16}
+
+[testenv]
+commands = python runtests.py {posargs}
+
+basepython =
+	py34: python3.4
+	py35: python3.5
+
+deps =
+	jinja2
+	dj18: django~=1.8.0
+	dj19: django~=1.9.0
+	dj110: django~=1.10.0
+	wt16: Wagtail~=1.6.0


### PR DESCRIPTION
Running with various configurations, it seems that wagtail metadata is
only compatible with Python 3, and Wagtail 1.6, so these restrictions
have been explicitly stated.

A Travis config has also been added.