### PR TITLE
Use `get_image_model_string` not `get_image_model`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 
 [testenv]
 commands = python runtests.py {posargs}
+pip_pre = True
 
 basepython =
 	py34: python3.4
@@ -16,4 +17,6 @@ deps =
 	dj18: django~=1.8.0
 	dj19: django~=1.9.0
 	dj110: django~=1.10.0
+	djHEAD: django
 	wt16: Wagtail~=1.6.0
+	wtHEAD: Wagtail

--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -1,22 +1,21 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel
-from wagtail.wagtailcore.models import Page, Site
+from wagtail.wagtailcore.models import Site
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
-from wagtail.wagtailimages.models import get_image_model
+
+from .utils import get_image_model_string
 
 TWITTER_CARD_TYPES = [
     ('summary', 'Summary card'),
     ('summary_large_image', 'Summary card with large image'),
 ]
 
-IMAGE_MODEL = get_image_model()
-
 
 class SiteMetadataPreferences(models.Model):
     site = models.OneToOneField(Site, unique=True, db_index=True, editable=False)
     site_image = models.ForeignKey(
-        IMAGE_MODEL,
+        get_image_model_string(),
         null=True,
         blank=True,
         related_name='+',
@@ -61,7 +60,7 @@ class MetadataMixin(object):
 
 class MetadataPageMixin(MetadataMixin, models.Model):
     search_image = models.ForeignKey(
-        IMAGE_MODEL,
+        get_image_model_string(),
         null=True,
         blank=True,
         related_name='+',


### PR DESCRIPTION
This prevents having to import `wagtail.wagtailimages.models`, and calling `apps.get_model()` before the apps might be ready.

An implementation of `get_image_model_string` will be coming in Wagtail 1.8

Fixes #20