### PR TITLE
Do not include tests in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     zip_safe=False,
     license='BSD License',
 
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests*']),
 
     include_package_data=True,
     package_data={},


### PR DESCRIPTION
Accidentally including the tests means that `from tests import foo` will import
something from `wagtailmetadata`, even if your package has a local `tests`
package used for testing. This caused me quite a headache to debug!