### PR TITLE
Make name of MetadataPageMixin.search_image translateable

### DIFF
--- a/wagtailmetadata/models.py
+++ b/wagtailmetadata/models.py
@@ -48,7 +48,8 @@ class MetadataPageMixin(MetadataMixin, models.Model):
         null=True,
         blank=True,
         related_name='+',
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
+        verbose_name=ugettext_lazy('Search image')
     )
 
     promote_panels = [


### PR DESCRIPTION
Currently the name of MetadataPageMixin.search_image cannot be translated. This pull request adds a translateable `verbose_name` to this field.